### PR TITLE
Fixes failing test

### DIFF
--- a/com.sjwebb.knime.slack/META-INF/MANIFEST.MF
+++ b/com.sjwebb.knime.slack/META-INF/MANIFEST.MF
@@ -12,9 +12,9 @@ Bundle-ClassPath: .,
 Bundle-Activator: com.sjwebb.knime.slack.plugin.GetChannelsNodePlugin
 Bundle-Vendor: Samuel Webb
 Require-Bundle: org.eclipse.core.runtime,
- org.knime.workbench.core;bundle-version="[3.0.0,4.0.0)",
- org.knime.workbench.repository;bundle-version="[3.0.0,4.0.0)",
- org.knime.base;bundle-version="[3.0.0,4.0.0)",
+ org.knime.workbench.core;bundle-version="[3.0.0,5.0.0)",
+ org.knime.workbench.repository;bundle-version="[3.0.0,5.0.0)",
+ org.knime.base;bundle-version="[3.0.0,5.0.0)",
  com.google.gson;bundle-version="2.7.0",
  org.hamcrest.core;bundle-version="1.3.0",
  org.slf4j.api;bundle-version="1.7.2",

--- a/com.sjwebb.knime.slack/src/com/sjwebb/knime/slack/api/SlackBotApi.java
+++ b/com.sjwebb.knime.slack/src/com/sjwebb/knime/slack/api/SlackBotApi.java
@@ -3,6 +3,7 @@ package com.sjwebb.knime.slack.api;
 import java.io.IOException;
 import java.util.List;
 import java.util.Optional;
+import java.util.stream.Collectors;
 
 import com.github.seratch.jslack.Slack;
 import com.github.seratch.jslack.api.methods.SlackApiException;
@@ -51,20 +52,42 @@ public class SlackBotApi {
 	}
 
 	/**
-	 * Get the list of channels
+	 * Get the list of non archived channels
 	 * 
 	 * @return
 	 * @throws IOException
 	 * @throws SlackApiException
 	 */
 	public List<Channel> getChannelList() throws IOException, SlackApiException {
+		return getChannelList(false);
+	}
+
+	/**
+	 * Get the list of channels
+	 * 
+	 * @param keepArchived should archived channels be kept
+	 * @return
+	 * @throws IOException
+	 * @throws SlackApiException
+	 */
+	public List<Channel> getChannelList(boolean keepArchived) throws IOException, SlackApiException {
 		ChannelsListResponse channelsResponse = slack.methods()
 				.channelsList(ChannelsListRequest.builder().token(token).build());
 
 
-		return channelsResponse.getChannels();
-	}
+		List<Channel> channels;
+		
+		if(keepArchived)
+		{
+			channels = channelsResponse.getChannels();
+		} else
+		{
+			channels = channelsResponse.getChannels().stream().filter(v -> !v.isArchived()).collect(Collectors.toList());
+		}
 
+		return channels;
+	}
+	
 	/**
 	 * Post a message to the given chanel
 	 * 


### PR DESCRIPTION
The nodes still worked correctly, test was failing due to change in workspace (additional channels added). 

This did however reveal that archived channels are reported by the Get Channels node. 

Rolling out change to not show archived channels to 3.7 branch