### PR TITLE
Increase limit from default 100 to 1000

### DIFF
--- a/com.sjwebb.knime.slack/src/com/sjwebb/knime/slack/api/SlackBotApi.java
+++ b/com.sjwebb.knime.slack/src/com/sjwebb/knime/slack/api/SlackBotApi.java
@@ -211,7 +211,7 @@ public class SlackBotApi
 		
 		// First find the conversation to get the ID
 		ConversationsListResponse listResponse = 
-				  slack.methods().conversationsList(req -> req.token(token).types(types).excludeArchived(true));
+				  slack.methods().conversationsList(req -> req.token(token).types(types).limit(1000).excludeArchived(true));
 		
 		Conversation conversation = listResponse.getChannels().stream()
 				  .filter(c -> c.getName().equals(channel))


### PR DESCRIPTION
The limit for finding a conversations in the sendMessageToChannel method didn't overide the default limit of 100 which could cause a channel to pass the found check but fail to be able to send the message. This is now set to 1000