### PR TITLE
Allow bot display name customisation

### DIFF
--- a/com.sjwebb.knime.slack/src/com/sjwebb/knime/slack/nodes/channels/history2/ChannelHistoryNodeFactory2.xml
+++ b/com.sjwebb.knime.slack/src/com/sjwebb/knime/slack/nodes/channels/history2/ChannelHistoryNodeFactory2.xml
@@ -7,15 +7,15 @@
     </shortDescription>
     
     <fullDescription>
-        <intro>Gets the history of the specified channel (version 2).
+        <intro>Gets the history of the specified channel (version 2). A maximum of 1000 messages will be retrieved.
         
         <p>
-        	<b>This node requires a user OAuth token. For more details see <a href="https://api.slack.com/methods/conversations.history">https://api.slack.com/methods/conversations.history</a> </b>
+        	<b>This node requires a user OAuth token. 
+        	For more details see <a href="https://api.slack.com/methods/conversations.history">https://api.slack.com/methods/conversations.history</a> </b>
         </p>
         
         <p>
             The following scopes must be set: channels:history, channels:read and groups:history.
-        
         </p>
         
         </intro>

--- a/com.sjwebb.knime.slack/src/com/sjwebb/knime/slack/nodes/messages/send/SendMessageNodeDialog.java
+++ b/com.sjwebb.knime.slack/src/com/sjwebb/knime/slack/nodes/messages/send/SendMessageNodeDialog.java
@@ -15,16 +15,24 @@ import org.knime.core.node.defaultnodesettings.DefaultNodeSettingsPane;
  */
 public class SendMessageNodeDialog extends DefaultNodeSettingsPane {
 
+	private SlackSendMessageSettings settings;
+	
     /**
      * New pane for configuring the SendMessage node.
      */
     protected SendMessageNodeDialog() {
-    	SlackSendMessageSettings settings = new SlackSendMessageSettings();
+    	settings = new SlackSendMessageSettings();
     	
     	addDialogComponent(settings.getDialogCompoinentOathToken());
     	addDialogComponent(settings.getDialogCompoinentChannel());
     	addDialogComponent(settings.getDialogCompoinentMessage());
     	
+    	createNewGroup("Username");
+    	setHorizontalPlacement(true);
+    	addDialogComponent(settings.getDialogComponentSetUsername());
+    	addDialogComponent(settings.getDialogComponentUsername());
+
     }
+    
 }
 

--- a/com.sjwebb.knime.slack/src/com/sjwebb/knime/slack/nodes/messages/send/SendMessageNodeFactory.xml
+++ b/com.sjwebb.knime.slack/src/com/sjwebb/knime/slack/nodes/messages/send/SendMessageNodeFactory.xml
@@ -9,11 +9,26 @@
     <fullDescription>
         <intro>
 			Send the given message to the specified channel on execution. No input table needs to be specified, if one is given it is passed through verbatim. 
+        
+        <p>
+               	API call details: <a href="https://api.slack.com/methods/chat.postMessage">https://api.slack.com/methods/chat.postMessage</a>
+        </p>        
+
+       	
+       	<p>
+       		<b>Notes on username:</b>
+       		By default the message will be sent and display with the apps name. If the chat:write:customize scope has been added then it is possible to 
+       		set a username parameter. If changing the display name / username of the source of the message is desirable then check 'Set username' and 
+       		provide the username to post the message as.
+       	</p>
+        
         </intro>
         
         <option name="Bot OAuth token">The OAth token of the bot to post as</option>
         <option name="Channel">The channel to post to</option>
         <option name="Message">The message to post</option>
+        <option name="Set username">Whether to use the custom provided username instead of bot name.</option>
+        <option name="Username">A custom username to set, this will overide the default bot name. Ignored if Set username is not checked.</option>
 
 
     </fullDescription>

--- a/com.sjwebb.knime.slack/src/com/sjwebb/knime/slack/nodes/messages/send/SendMessageNodeModel.java
+++ b/com.sjwebb.knime.slack/src/com/sjwebb/knime/slack/nodes/messages/send/SendMessageNodeModel.java
@@ -1,5 +1,7 @@
 package com.sjwebb.knime.slack.nodes.messages.send;
 
+import java.util.Optional;
+
 import org.knime.core.data.DataTableSpec;
 import org.knime.core.data.DataTableSpecCreator;
 import org.knime.core.node.BufferedDataContainer;
@@ -49,7 +51,7 @@ public class SendMessageNodeModel extends LocalSettingsNodeModel<SlackSendMessag
 //		
 //		api.postMessage(channel.get(), localSettings.getMessage());
 		
-		api.sendMessageToChannel(localSettings.getChannel(), localSettings.getMessage());
+		api.sendMessageToChannel(localSettings.getChannel(), localSettings.getMessage(), localSettings.getOptionalUsername());
 		
 		BufferedDataTable[] out;
 		

--- a/com.sjwebb.knime.slack/src/com/sjwebb/knime/slack/nodes/messages/send/SlackSendMessageSettings.java
+++ b/com.sjwebb.knime.slack/src/com/sjwebb/knime/slack/nodes/messages/send/SlackSendMessageSettings.java
@@ -1,6 +1,15 @@
 package com.sjwebb.knime.slack.nodes.messages.send;
 
+import java.util.Optional;
+
+import javax.swing.event.ChangeEvent;
+import javax.swing.event.ChangeListener;
+
+import org.knime.core.node.InvalidSettingsException;
+import org.knime.core.node.NodeSettingsRO;
+import org.knime.core.node.NodeSettingsWO;
 import org.knime.core.node.defaultnodesettings.DialogComponent;
+import org.knime.core.node.defaultnodesettings.DialogComponentBoolean;
 import org.knime.core.node.defaultnodesettings.DialogComponentMultiLineString;
 import org.knime.core.node.defaultnodesettings.DialogComponentString;
 import org.knime.core.node.defaultnodesettings.SettingsModelBoolean;
@@ -14,6 +23,8 @@ public class SlackSendMessageSettings extends NodeSettingCollection {
 	public static final String OATH_TOKEN = "oathToken";
 	public static final String CHANNEL = "channel";
 	public static final String MESSAGE = "Message";
+	public static final String USERNAME =  "Username";
+	public static final String SET_USERNAME = "Set-username";
 
 	
 	@Override
@@ -21,8 +32,24 @@ public class SlackSendMessageSettings extends NodeSettingCollection {
 		addSetting(OATH_TOKEN, new SettingsModelString(OATH_TOKEN, getPreferenceOAuthToken()));
 		addSetting(CHANNEL, new SettingsModelString(CHANNEL, ""));
 		addSetting(MESSAGE, new SettingsModelString(MESSAGE, "Hello from KNIME"));
+		
+		SettingsModelString username = new SettingsModelString(USERNAME, "KNIME Bot");
+		username.setEnabled(false);
+		
+		addSetting(USERNAME, username);
 
-
+		SettingsModelBoolean setUsername = new SettingsModelBoolean(SET_USERNAME, false);
+		addSetting(SET_USERNAME, setUsername);
+		
+		
+		setUsername.addChangeListener(new ChangeListener() 
+		{
+			@Override
+			public void stateChanged(ChangeEvent e) 
+			{
+				username.setEnabled(setUsername.getBooleanValue());
+			}
+		});
 	}
 
 	
@@ -46,6 +73,20 @@ public class SlackSendMessageSettings extends NodeSettingCollection {
 		return getSetting(MESSAGE, SettingsModelString.class).getStringValue();
 	}
 	
+	public Optional<String> getOptionalUsername()
+	{
+		return isSetUsername() ? Optional.of(getUsername()) : Optional.empty();
+	}
+	
+	public String getUsername() {
+		return getSetting(USERNAME, SettingsModelString.class).getStringValue();
+	}
+	
+	public boolean isSetUsername()
+	{
+		return getBooleanValue(SET_USERNAME);
+	}
+	
 	public String getChannel()
 	{
 		return getSetting(CHANNEL, SettingsModelString.class).getStringValue();
@@ -61,6 +102,14 @@ public class SlackSendMessageSettings extends NodeSettingCollection {
 		return new DialogComponentString(getSetting(CHANNEL, SettingsModelString.class), "Channel to send message to");
 	}
 	
-
-
+	public DialogComponent getDialogComponentUsername()
+	{
+		return new DialogComponentString(getSetting(USERNAME, SettingsModelString.class), "Username");
+	}
+	
+	public DialogComponent getDialogComponentSetUsername()
+	{
+		return new DialogComponentBoolean(getSetting(SET_USERNAME, SettingsModelBoolean.class), "Set username");
+	}	
+	
 }

--- a/com.sjwebb.knime.slack/src/com/sjwebb/knime/slack/nodes/messages/send/row/SendRowMessageNodeDialog.java
+++ b/com.sjwebb.knime.slack/src/com/sjwebb/knime/slack/nodes/messages/send/row/SendRowMessageNodeDialog.java
@@ -27,6 +27,11 @@ public class SendRowMessageNodeDialog extends DefaultNodeSettingsPane {
     	setHorizontalPlacement(true);
     	addDialogComponent(settings.getDialogComponentChannel());
     	addDialogComponent(settings.getDialogComponentMessage());
+    	
+    	createNewGroup("Username");
+    	setHorizontalPlacement(true);
+    	addDialogComponent(settings.getDialogComponentSetUsername());
+    	addDialogComponent(settings.getDialogComponentUsername());
 
     }
 }

--- a/com.sjwebb.knime.slack/src/com/sjwebb/knime/slack/nodes/messages/send/row/SendRowMessageNodeFactory.xml
+++ b/com.sjwebb.knime.slack/src/com/sjwebb/knime/slack/nodes/messages/send/row/SendRowMessageNodeFactory.xml
@@ -8,13 +8,28 @@
     
     <fullDescription>
         <intro>Send messages to slack. This node is capable of sending multiple messages to multiple channels. Specify the channel name
-        and the message in the dialog.</intro>
+        and the message in the dialog.
+        
+        <p>
+               	API call details: <a href="https://api.slack.com/methods/chat.postMessage">https://api.slack.com/methods/chat.postMessage</a>
+        </p>        
+
+       	<p>
+       		<b>Notes on username:</b>
+       		By default the message will be sent and display with the apps name. If the chat:write:customize scope has been added then it is possible to 
+       		set a username parameter. If changing the display name / username of the source of the message is desirable then check 'Set username' and 
+       		provide the username to post the message as.
+       	</p>
+        
+        </intro>
         
         
         <option name="OAth token">The OAth token to use for the action. Initially populated by the value in the preferences.</option>
         <option name="Channel">The name of the channel to send the message to.</option>
         <option name="Message">The message content to send.</option>
-        
+        <option name="Set username">Whether to use the custom provided username instead of bot name.</option>
+        <option name="Username">A custom username to set, this will overide the default bot name. Ignored if Set username is not checked.</option>
+
     </fullDescription>
     
     <ports>

--- a/com.sjwebb.knime.slack/src/com/sjwebb/knime/slack/nodes/messages/send/row/SendRowMessageNodeModel.java
+++ b/com.sjwebb.knime.slack/src/com/sjwebb/knime/slack/nodes/messages/send/row/SendRowMessageNodeModel.java
@@ -69,7 +69,7 @@ public class SendRowMessageNodeModel extends LocalSettingsNodeModel<SendRowMessa
 				{
 					try 
 					{
-						String timestamp = api.sendMessageToChannel(channel, message);
+						String timestamp = api.sendMessageToChannel(channel, message, localSettings.getOptionalUsername());
 						addRow(container, row, timestamp);
 					} catch (Exception e) 
 					{

--- a/com.sjwebb.knime.slack/src/com/sjwebb/knime/slack/nodes/messages/send/row/SendRowMessageSettings.java
+++ b/com.sjwebb.knime.slack/src/com/sjwebb/knime/slack/nodes/messages/send/row/SendRowMessageSettings.java
@@ -1,8 +1,17 @@
 package com.sjwebb.knime.slack.nodes.messages.send.row;
 
+import java.util.Optional;
+
+import javax.swing.event.ChangeEvent;
+import javax.swing.event.ChangeListener;
+
 import org.knime.core.data.StringValue;
 import org.knime.core.node.defaultnodesettings.DialogComponent;
+import org.knime.core.node.defaultnodesettings.DialogComponentBoolean;
+import org.knime.core.node.defaultnodesettings.DialogComponentString;
+import org.knime.core.node.defaultnodesettings.SettingsModelBoolean;
 import org.knime.core.node.defaultnodesettings.SettingsModelColumnName;
+import org.knime.core.node.defaultnodesettings.SettingsModelString;
 
 import com.sjwebb.knime.slack.util.SlackOathTokenSettings;
 
@@ -18,6 +27,10 @@ public class SendRowMessageSettings extends SlackOathTokenSettings {
 
 	public static final String CONFIG_CHANNEL = "cfgChannel";
 	public static final String CONFIG_MESSAGE = "cfgMessage";
+	
+	public static final String USERNAME =  "Username";
+	public static final String SET_USERNAME = "Set-username";
+
 
 	
 	@Override
@@ -26,6 +39,38 @@ public class SendRowMessageSettings extends SlackOathTokenSettings {
 		
 		addSetting(CONFIG_CHANNEL, new SettingsModelColumnName(CONFIG_CHANNEL, "channel"));
 		addSetting(CONFIG_MESSAGE, new SettingsModelColumnName(CONFIG_MESSAGE, "message"));
+
+		SettingsModelString username = new SettingsModelString(USERNAME, "KNIME Bot");
+		username.setEnabled(false);
+		
+		addSetting(USERNAME, username);
+
+		SettingsModelBoolean setUsername = new SettingsModelBoolean(SET_USERNAME, false);
+		addSetting(SET_USERNAME, setUsername);
+		
+		
+		setUsername.addChangeListener(new ChangeListener() 
+		{
+			@Override
+			public void stateChanged(ChangeEvent e) 
+			{
+				username.setEnabled(setUsername.getBooleanValue());
+			}
+		});
+	}
+	
+	public String getUsername() {
+		return getSetting(USERNAME, SettingsModelString.class).getStringValue();
+	}
+	
+	public boolean isSetUsername()
+	{
+		return getBooleanValue(SET_USERNAME);
+	}
+	
+	public Optional<String> getOptionalUsername()
+	{
+		return isSetUsername() ? Optional.of(getUsername()) : Optional.empty();
 	}
 	
 
@@ -64,6 +109,16 @@ public class SendRowMessageSettings extends SlackOathTokenSettings {
 	public DialogComponent getDialogComponentMessage()
 	{
 		return getDialogColumnNameSelection(CONFIG_MESSAGE, "Message", 0, StringValue.class);
+	}
+	
+	public DialogComponent getDialogComponentUsername()
+	{
+		return new DialogComponentString(getSetting(USERNAME, SettingsModelString.class), "Username");
+	}
+	
+	public DialogComponent getDialogComponentSetUsername()
+	{
+		return new DialogComponentBoolean(getSetting(SET_USERNAME, SettingsModelBoolean.class), "Set username");
 	}
 
 }


### PR DESCRIPTION
When sending a message to a channel it's not possible to optionally specify a username for the bot

Increased channel history limit to 1000