### PR TITLE
Allow specification of iconUrl or iconEmoji

### DIFF
--- a/com.sjwebb.knime.slack/src/com/sjwebb/knime/slack/nodes/messages/send/SendMessageNodeDialog.java
+++ b/com.sjwebb.knime.slack/src/com/sjwebb/knime/slack/nodes/messages/send/SendMessageNodeDialog.java
@@ -2,6 +2,8 @@ package com.sjwebb.knime.slack.nodes.messages.send;
 
 import org.knime.core.node.defaultnodesettings.DefaultNodeSettingsPane;
 
+import com.sjwebb.knime.slack.util.MessageSendingDialog;
+
 /**
  * <code>NodeDialog</code> for the "SendMessage" Node.
  * Send a slack message to a designated channel
@@ -13,25 +15,21 @@ import org.knime.core.node.defaultnodesettings.DefaultNodeSettingsPane;
  * 
  * @author Samuel Webb
  */
-public class SendMessageNodeDialog extends DefaultNodeSettingsPane {
+public class SendMessageNodeDialog extends MessageSendingDialog<SlackSendMessageSettings>  {
 
-	private SlackSendMessageSettings settings;
 	
     /**
      * New pane for configuring the SendMessage node.
      */
     protected SendMessageNodeDialog() {
-    	settings = new SlackSendMessageSettings();
+    	super();
+    	super.settings = new SlackSendMessageSettings();
     	
     	addDialogComponent(settings.getDialogCompoinentOathToken());
     	addDialogComponent(settings.getDialogCompoinentChannel());
     	addDialogComponent(settings.getDialogCompoinentMessage());
     	
-    	createNewGroup("Username");
-    	setHorizontalPlacement(true);
-    	addDialogComponent(settings.getDialogComponentSetUsername());
-    	addDialogComponent(settings.getDialogComponentUsername());
-
+    	addAdvancedSettings();
     }
     
 }

--- a/com.sjwebb.knime.slack/src/com/sjwebb/knime/slack/nodes/messages/send/SendMessageNodeModel.java
+++ b/com.sjwebb.knime.slack/src/com/sjwebb/knime/slack/nodes/messages/send/SendMessageNodeModel.java
@@ -51,7 +51,7 @@ public class SendMessageNodeModel extends LocalSettingsNodeModel<SlackSendMessag
 //		
 //		api.postMessage(channel.get(), localSettings.getMessage());
 		
-		api.sendMessageToChannel(localSettings.getChannel(), localSettings.getMessage(), localSettings.getOptionalUsername());
+		api.sendMessageToChannel(localSettings.getChannel(), localSettings.getMessage(), localSettings.getOptionalUsername(), localSettings.getOptionalIconUrl(), localSettings.getOptionalIconEmoji());
 		
 		BufferedDataTable[] out;
 		

--- a/com.sjwebb.knime.slack/src/com/sjwebb/knime/slack/nodes/messages/send/SlackSendMessageSettings.java
+++ b/com.sjwebb.knime.slack/src/com/sjwebb/knime/slack/nodes/messages/send/SlackSendMessageSettings.java
@@ -1,91 +1,35 @@
 package com.sjwebb.knime.slack.nodes.messages.send;
 
-import java.util.Optional;
-
-import javax.swing.event.ChangeEvent;
-import javax.swing.event.ChangeListener;
-
-import org.knime.core.node.InvalidSettingsException;
-import org.knime.core.node.NodeSettingsRO;
-import org.knime.core.node.NodeSettingsWO;
 import org.knime.core.node.defaultnodesettings.DialogComponent;
-import org.knime.core.node.defaultnodesettings.DialogComponentBoolean;
 import org.knime.core.node.defaultnodesettings.DialogComponentMultiLineString;
 import org.knime.core.node.defaultnodesettings.DialogComponentString;
-import org.knime.core.node.defaultnodesettings.SettingsModelBoolean;
 import org.knime.core.node.defaultnodesettings.SettingsModelString;
 
-import com.sjwebb.knime.slack.util.NodeSettingCollection;
-import com.sjwebb.knime.slack.util.SlackBotApiFactory;
+import com.sjwebb.knime.slack.util.SharedSendMessageSettings;
 
-public class SlackSendMessageSettings extends NodeSettingCollection {
+public class SlackSendMessageSettings extends SharedSendMessageSettings {
 
-	public static final String OATH_TOKEN = "oathToken";
 	public static final String CHANNEL = "channel";
 	public static final String MESSAGE = "Message";
-	public static final String USERNAME =  "Username";
-	public static final String SET_USERNAME = "Set-username";
 
 	
 	@Override
 	protected void addSettings() {
-		addSetting(OATH_TOKEN, new SettingsModelString(OATH_TOKEN, getPreferenceOAuthToken()));
+		super.addSettings();
+		
+
 		addSetting(CHANNEL, new SettingsModelString(CHANNEL, ""));
 		addSetting(MESSAGE, new SettingsModelString(MESSAGE, "Hello from KNIME"));
 		
-		SettingsModelString username = new SettingsModelString(USERNAME, "KNIME Bot");
-		username.setEnabled(false);
-		
-		addSetting(USERNAME, username);
-
-		SettingsModelBoolean setUsername = new SettingsModelBoolean(SET_USERNAME, false);
-		addSetting(SET_USERNAME, setUsername);
-		
-		
-		setUsername.addChangeListener(new ChangeListener() 
-		{
-			@Override
-			public void stateChanged(ChangeEvent e) 
-			{
-				username.setEnabled(setUsername.getBooleanValue());
-			}
-		});
 	}
 
 	
-	private String getPreferenceOAuthToken() 
-	{
-		return SlackBotApiFactory.getDefaultOAuthToken();
-	}
-	
-	public String getOathToken()
-	{
-		return getSetting(OATH_TOKEN, SettingsModelString.class).getStringValue();
-	}
-	
-	public DialogComponent getDialogCompoinentOathToken()
-	{
-		return new DialogComponentString(getSetting(OATH_TOKEN, SettingsModelString.class), "Bot OAuth token");
-	}
 	
 	public String getMessage()
 	{
 		return getSetting(MESSAGE, SettingsModelString.class).getStringValue();
 	}
 	
-	public Optional<String> getOptionalUsername()
-	{
-		return isSetUsername() ? Optional.of(getUsername()) : Optional.empty();
-	}
-	
-	public String getUsername() {
-		return getSetting(USERNAME, SettingsModelString.class).getStringValue();
-	}
-	
-	public boolean isSetUsername()
-	{
-		return getBooleanValue(SET_USERNAME);
-	}
 	
 	public String getChannel()
 	{
@@ -101,15 +45,5 @@ public class SlackSendMessageSettings extends NodeSettingCollection {
 	{
 		return new DialogComponentString(getSetting(CHANNEL, SettingsModelString.class), "Channel to send message to");
 	}
-	
-	public DialogComponent getDialogComponentUsername()
-	{
-		return new DialogComponentString(getSetting(USERNAME, SettingsModelString.class), "Username");
-	}
-	
-	public DialogComponent getDialogComponentSetUsername()
-	{
-		return new DialogComponentBoolean(getSetting(SET_USERNAME, SettingsModelBoolean.class), "Set username");
-	}	
-	
+
 }

--- a/com.sjwebb.knime.slack/src/com/sjwebb/knime/slack/nodes/messages/send/row/SendRowMessageNodeDialog.java
+++ b/com.sjwebb.knime.slack/src/com/sjwebb/knime/slack/nodes/messages/send/row/SendRowMessageNodeDialog.java
@@ -2,6 +2,8 @@ package com.sjwebb.knime.slack.nodes.messages.send.row;
 
 import org.knime.core.node.defaultnodesettings.DefaultNodeSettingsPane;
 
+import com.sjwebb.knime.slack.util.MessageSendingDialog;
+
 /**
  * <code>NodeDialog</code> for the "SendRowMessage" Node.
  * Send a message based on contents selected from a table row.
@@ -13,14 +15,15 @@ import org.knime.core.node.defaultnodesettings.DefaultNodeSettingsPane;
  * 
  * @author Samuel Webb
  */
-public class SendRowMessageNodeDialog extends DefaultNodeSettingsPane {
+public class SendRowMessageNodeDialog extends MessageSendingDialog<SendRowMessageSettings> {
 
     /**
      * New pane for configuring the SendRowMessage node.
      */
     protected SendRowMessageNodeDialog() {
+    	super();
     	
-    	SendRowMessageSettings settings = new SendRowMessageSettings();
+    	super.settings = new SendRowMessageSettings();
     	addDialogComponent(settings.getDialogCompoinentOathToken());
     	
     	createNewGroup("Message details");
@@ -28,11 +31,10 @@ public class SendRowMessageNodeDialog extends DefaultNodeSettingsPane {
     	addDialogComponent(settings.getDialogComponentChannel());
     	addDialogComponent(settings.getDialogComponentMessage());
     	
-    	createNewGroup("Username");
-    	setHorizontalPlacement(true);
-    	addDialogComponent(settings.getDialogComponentSetUsername());
-    	addDialogComponent(settings.getDialogComponentUsername());
-
+    	
+    	addAdvancedSettings();
     }
+    
+  
 }
 

--- a/com.sjwebb.knime.slack/src/com/sjwebb/knime/slack/nodes/messages/send/row/SendRowMessageNodeModel.java
+++ b/com.sjwebb.knime.slack/src/com/sjwebb/knime/slack/nodes/messages/send/row/SendRowMessageNodeModel.java
@@ -69,7 +69,7 @@ public class SendRowMessageNodeModel extends LocalSettingsNodeModel<SendRowMessa
 				{
 					try 
 					{
-						String timestamp = api.sendMessageToChannel(channel, message, localSettings.getOptionalUsername());
+						String timestamp = api.sendMessageToChannel(channel, message, localSettings.getOptionalUsername(), localSettings.getOptionalIconUrl(), localSettings.getOptionalIconEmoji());
 						addRow(container, row, timestamp);
 					} catch (Exception e) 
 					{

--- a/com.sjwebb.knime.slack/src/com/sjwebb/knime/slack/nodes/messages/send/row/SendRowMessageSettings.java
+++ b/com.sjwebb.knime.slack/src/com/sjwebb/knime/slack/nodes/messages/send/row/SendRowMessageSettings.java
@@ -1,19 +1,10 @@
 package com.sjwebb.knime.slack.nodes.messages.send.row;
 
-import java.util.Optional;
-
-import javax.swing.event.ChangeEvent;
-import javax.swing.event.ChangeListener;
-
 import org.knime.core.data.StringValue;
 import org.knime.core.node.defaultnodesettings.DialogComponent;
-import org.knime.core.node.defaultnodesettings.DialogComponentBoolean;
-import org.knime.core.node.defaultnodesettings.DialogComponentString;
-import org.knime.core.node.defaultnodesettings.SettingsModelBoolean;
 import org.knime.core.node.defaultnodesettings.SettingsModelColumnName;
-import org.knime.core.node.defaultnodesettings.SettingsModelString;
 
-import com.sjwebb.knime.slack.util.SlackOathTokenSettings;
+import com.sjwebb.knime.slack.util.SharedSendMessageSettings;
 
 /**
  * The settings for the SendRowMessage node. Provides settings and dialog components
@@ -23,14 +14,11 @@ import com.sjwebb.knime.slack.util.SlackOathTokenSettings;
  * @author Samuel
  *
  */
-public class SendRowMessageSettings extends SlackOathTokenSettings {
+public class SendRowMessageSettings extends SharedSendMessageSettings {
 
 	public static final String CONFIG_CHANNEL = "cfgChannel";
 	public static final String CONFIG_MESSAGE = "cfgMessage";
 	
-	public static final String USERNAME =  "Username";
-	public static final String SET_USERNAME = "Set-username";
-
 
 	
 	@Override
@@ -40,38 +28,9 @@ public class SendRowMessageSettings extends SlackOathTokenSettings {
 		addSetting(CONFIG_CHANNEL, new SettingsModelColumnName(CONFIG_CHANNEL, "channel"));
 		addSetting(CONFIG_MESSAGE, new SettingsModelColumnName(CONFIG_MESSAGE, "message"));
 
-		SettingsModelString username = new SettingsModelString(USERNAME, "KNIME Bot");
-		username.setEnabled(false);
-		
-		addSetting(USERNAME, username);
+	}
+	
 
-		SettingsModelBoolean setUsername = new SettingsModelBoolean(SET_USERNAME, false);
-		addSetting(SET_USERNAME, setUsername);
-		
-		
-		setUsername.addChangeListener(new ChangeListener() 
-		{
-			@Override
-			public void stateChanged(ChangeEvent e) 
-			{
-				username.setEnabled(setUsername.getBooleanValue());
-			}
-		});
-	}
-	
-	public String getUsername() {
-		return getSetting(USERNAME, SettingsModelString.class).getStringValue();
-	}
-	
-	public boolean isSetUsername()
-	{
-		return getBooleanValue(SET_USERNAME);
-	}
-	
-	public Optional<String> getOptionalUsername()
-	{
-		return isSetUsername() ? Optional.of(getUsername()) : Optional.empty();
-	}
 	
 
 	/**
@@ -111,14 +70,5 @@ public class SendRowMessageSettings extends SlackOathTokenSettings {
 		return getDialogColumnNameSelection(CONFIG_MESSAGE, "Message", 0, StringValue.class);
 	}
 	
-	public DialogComponent getDialogComponentUsername()
-	{
-		return new DialogComponentString(getSetting(USERNAME, SettingsModelString.class), "Username");
-	}
-	
-	public DialogComponent getDialogComponentSetUsername()
-	{
-		return new DialogComponentBoolean(getSetting(SET_USERNAME, SettingsModelBoolean.class), "Set username");
-	}
 
 }

--- a/com.sjwebb.knime.slack/src/com/sjwebb/knime/slack/nodes/user/messages/send/MessageSlackUserNodeDialog.java
+++ b/com.sjwebb.knime.slack/src/com/sjwebb/knime/slack/nodes/user/messages/send/MessageSlackUserNodeDialog.java
@@ -2,6 +2,8 @@ package com.sjwebb.knime.slack.nodes.user.messages.send;
 
 import org.knime.core.node.defaultnodesettings.DefaultNodeSettingsPane;
 
+import com.sjwebb.knime.slack.util.MessageSendingDialog;
+
 /**
  * <code>NodeDialog</code> for the "MessageSlackUser" Node.
  * Send a direct message to a KNIME user
@@ -13,24 +15,24 @@ import org.knime.core.node.defaultnodesettings.DefaultNodeSettingsPane;
  * 
  * @author Sam Webb
  */
-public class MessageSlackUserNodeDialog extends DefaultNodeSettingsPane {
+public class MessageSlackUserNodeDialog extends MessageSendingDialog<MessageSlackUserSettings> {
 
     /**
      * New pane for configuring the MessageSlackUser node.
      */
     protected MessageSlackUserNodeDialog() 
     {
-    	MessageSlackUserSettings settings = new MessageSlackUserSettings();
+    	super();
+    	super.settings = new MessageSlackUserSettings();
     	
     	addDialogComponent(settings.getDialogCompoinentOathToken());
     	addDialogComponent(settings.getDialogComponentUser());
     	addDialogComponent(settings.getDialogCompoinentMessage());
     	addDialogComponent(settings.getDialogComponentFailOnError());
     
-    	createNewGroup("Username");
-    	setHorizontalPlacement(true);
-    	addDialogComponent(settings.getDialogComponentSetUsername());
-    	addDialogComponent(settings.getDialogComponentUsername());
+
+    
+    	addAdvancedSettings();
     }
 }
 

--- a/com.sjwebb.knime.slack/src/com/sjwebb/knime/slack/nodes/user/messages/send/MessageSlackUserNodeModel.java
+++ b/com.sjwebb.knime.slack/src/com/sjwebb/knime/slack/nodes/user/messages/send/MessageSlackUserNodeModel.java
@@ -1,5 +1,7 @@
 package com.sjwebb.knime.slack.nodes.user.messages.send;
 
+import java.util.Optional;
+
 import org.knime.core.data.DataTableSpec;
 import org.knime.core.data.DataTableSpecCreator;
 import org.knime.core.node.BufferedDataContainer;
@@ -43,7 +45,7 @@ public class MessageSlackUserNodeModel extends LocalSettingsNodeModel<MessageSla
 		ChatPostMessageResponse response = null;
 		try
 		{
-			response = api.directMessage(localSettings.getUser(), localSettings.getMessage(), localSettings.getOptionalUsername());
+			response = api.directMessage(localSettings.getUser(), localSettings.getMessage(), localSettings.getOptionalUsername(), localSettings.getOptionalIconUrl(), localSettings.getOptionalIconEmoji());
 			
 			if(!response.isOk())
 			{

--- a/com.sjwebb.knime.slack/src/com/sjwebb/knime/slack/nodes/user/messages/send/MessageSlackUserSettings.java
+++ b/com.sjwebb.knime.slack/src/com/sjwebb/knime/slack/nodes/user/messages/send/MessageSlackUserSettings.java
@@ -1,54 +1,27 @@
 package com.sjwebb.knime.slack.nodes.user.messages.send;
 
-import java.util.Optional;
-
-import javax.swing.event.ChangeEvent;
-import javax.swing.event.ChangeListener;
-
 import org.knime.core.node.defaultnodesettings.DialogComponent;
-import org.knime.core.node.defaultnodesettings.DialogComponentBoolean;
 import org.knime.core.node.defaultnodesettings.DialogComponentMultiLineString;
 import org.knime.core.node.defaultnodesettings.DialogComponentString;
 import org.knime.core.node.defaultnodesettings.SettingsModelBoolean;
 import org.knime.core.node.defaultnodesettings.SettingsModelString;
 
-import com.sjwebb.knime.slack.util.NodeSettingCollection;
-import com.sjwebb.knime.slack.util.SlackBotApiFactory;
+import com.sjwebb.knime.slack.util.SharedSendMessageSettings;
 
-public class MessageSlackUserSettings extends NodeSettingCollection {
+public class MessageSlackUserSettings extends SharedSendMessageSettings {
 
-	public static final String OATH_TOKEN = "oathToken";
 	public static final String USER = "channel";
 	public static final String MESSAGE = "Message";
 	public static final String FAIL_ON_ERROR = "failOnError";
 	
-	public static final String USERNAME =  "Username";
-	public static final String SET_USERNAME = "Set-username";
+
 	
 	@Override
 	protected void addSettings() {
-		addSetting(OATH_TOKEN, new SettingsModelString(OATH_TOKEN, getPreferenceOAuthToken()));
+		super.addSettings();
 		addSetting(USER, new SettingsModelString(USER, ""));
 		addSetting(MESSAGE, new SettingsModelString(MESSAGE, "Hello from KNIME"));
 		addSetting(FAIL_ON_ERROR, new SettingsModelBoolean(FAIL_ON_ERROR, true));
-		
-		SettingsModelString username = new SettingsModelString(USERNAME, "KNIME Bot");
-		username.setEnabled(false);
-		
-		addSetting(USERNAME, username);
-
-		SettingsModelBoolean setUsername = new SettingsModelBoolean(SET_USERNAME, false);
-		addSetting(SET_USERNAME, setUsername);
-		
-		
-		setUsername.addChangeListener(new ChangeListener() 
-		{
-			@Override
-			public void stateChanged(ChangeEvent e) 
-			{
-				username.setEnabled(setUsername.getBooleanValue());
-			}
-		});
 	}
 
 	
@@ -57,20 +30,6 @@ public class MessageSlackUserSettings extends NodeSettingCollection {
 		return getBooleanValue(FAIL_ON_ERROR);
 	}
 	
-	private String getPreferenceOAuthToken() 
-	{
-		return SlackBotApiFactory.getDefaultOAuthToken();
-	}
-	
-	public String getOathToken()
-	{
-		return getSetting(OATH_TOKEN, SettingsModelString.class).getStringValue();
-	}
-	
-	public DialogComponent getDialogCompoinentOathToken()
-	{
-		return new DialogComponentString(getSetting(OATH_TOKEN, SettingsModelString.class), "OAuth token");
-	}
 	
 	public String getMessage()
 	{
@@ -97,28 +56,5 @@ public class MessageSlackUserSettings extends NodeSettingCollection {
 		return getBooleanComponent(FAIL_ON_ERROR, "Fail on error");
 	}
 	
-	public Optional<String> getOptionalUsername()
-	{
-		return isSetUsername() ? Optional.of(getUsername()) : Optional.empty();
-	}
-	
-	
-	public String getUsername() {
-		return getSetting(USERNAME, SettingsModelString.class).getStringValue();
-	}
-	
-	public boolean isSetUsername()
-	{
-		return getBooleanValue(SET_USERNAME);
-	}
-	
-	public DialogComponent getDialogComponentUsername()
-	{
-		return new DialogComponentString(getSetting(USERNAME, SettingsModelString.class), "Username");
-	}
-	
-	public DialogComponent getDialogComponentSetUsername()
-	{
-		return new DialogComponentBoolean(getSetting(SET_USERNAME, SettingsModelBoolean.class), "Set username");
-	}	
+
 }

--- a/com.sjwebb.knime.slack/src/com/sjwebb/knime/slack/util/MessageSendingDialog.java
+++ b/com.sjwebb.knime.slack/src/com/sjwebb/knime/slack/util/MessageSendingDialog.java
@@ -1,0 +1,38 @@
+package com.sjwebb.knime.slack.util;
+
+import org.knime.core.node.defaultnodesettings.DefaultNodeSettingsPane;
+
+/**
+ * Provices the functionality for adding the advanced tab with the message sending configuration components
+ * 
+ * @author Sam Webb
+ * @since 28/04/2020
+ * 
+ * @param <T>
+ */
+public class MessageSendingDialog<T extends SharedSendMessageSettings> extends DefaultNodeSettingsPane 
+{
+	protected T settings;
+	
+	public MessageSendingDialog() {
+		super();
+	}
+	
+	protected void addAdvancedSettings()
+	{
+    	createNewTab("Advanced");
+    	createNewGroup("Username");
+    	setHorizontalPlacement(true);
+    	addDialogComponent(settings.getDialogComponentSetUsername());
+    	addDialogComponent(settings.getDialogComponentUsername());
+    	
+    	createNewGroup("Icon");
+    	addDialogComponent(settings.getDialogComponentSetIconUrl());
+    	addDialogComponent(settings.getDialogComponentIconUrl());
+    	setHorizontalPlacement(false);
+    	setHorizontalPlacement(true);
+       	addDialogComponent(settings.getDialogComponentSetIconEmoji());
+    	addDialogComponent(settings.getDialogComponentIconEmoji());
+	}
+
+}

--- a/com.sjwebb.knime.slack/src/com/sjwebb/knime/slack/util/SharedSendMessageSettings.java
+++ b/com.sjwebb.knime.slack/src/com/sjwebb/knime/slack/util/SharedSendMessageSettings.java
@@ -1,0 +1,157 @@
+package com.sjwebb.knime.slack.util;
+
+import java.util.Optional;
+
+import javax.swing.event.ChangeEvent;
+import javax.swing.event.ChangeListener;
+
+import org.knime.core.node.defaultnodesettings.DialogComponent;
+import org.knime.core.node.defaultnodesettings.DialogComponentBoolean;
+import org.knime.core.node.defaultnodesettings.DialogComponentString;
+import org.knime.core.node.defaultnodesettings.SettingsModelBoolean;
+import org.knime.core.node.defaultnodesettings.SettingsModelString;
+
+/**
+ * Settings for nodes that can send messages
+ * 
+ * @author Sam Webb
+ * @since 28/04/2020
+ */
+public class SharedSendMessageSettings extends SlackOathTokenSettings 
+{
+	
+	public static final String USERNAME =  "Username";
+	public static final String SET_USERNAME = "Set-username";
+	
+	public static final String ICON_URL =  "ICON_URL";
+	public static final String SET_ICON_URL = "SET_ICON_URL";
+	
+	public static final String ICON_EMOJI =  "ICON_EMOJI";
+	public static final String SET_ICON_EMOJI = "SET_ICON_EMOJI";
+	
+	
+	private static final String DEFAULT_URL = "https://forum-cdn.knime.com/uploads/default/original/1X/ab3ccf34482a0329361734a18199390177204f15.png";
+	private static final String DEFAULT_EMOJI = ":chart_with_upwards_trend:";
+
+	@Override
+	protected void addSettings() 
+	{
+		super.addSettings();
+		
+		// Username
+		SettingsModelString username = new SettingsModelString(USERNAME, "KNIME Bot");
+		username.setEnabled(false);
+		
+		addSetting(USERNAME, username);
+
+		SettingsModelBoolean setUsername = new SettingsModelBoolean(SET_USERNAME, false);
+		addSetting(SET_USERNAME, setUsername);
+		
+		
+		setUsername.addChangeListener(new ChangeListener() 
+		{
+			@Override
+			public void stateChanged(ChangeEvent e) 
+			{
+				username.setEnabled(setUsername.getBooleanValue());
+			}
+		});
+		
+		// Icon URL
+		SettingsModelString iconUrl = new SettingsModelString(ICON_URL, DEFAULT_URL);
+		iconUrl.setEnabled(false);
+		
+		addSetting(ICON_URL, iconUrl);
+
+		SettingsModelBoolean setIconUrl = new SettingsModelBoolean(SET_ICON_URL, false);
+		addSetting(SET_ICON_URL, setIconUrl);
+		
+		
+		setIconUrl.addChangeListener(new ChangeListener() 
+		{
+			@Override
+			public void stateChanged(ChangeEvent e) 
+			{
+				iconUrl.setEnabled(setIconUrl.getBooleanValue());
+			}
+		});
+		
+		// Icon Emoji
+		SettingsModelString iconEmoji = new SettingsModelString(ICON_EMOJI, DEFAULT_EMOJI);
+		iconEmoji.setEnabled(false);
+		
+		addSetting(ICON_EMOJI, iconEmoji);
+
+		SettingsModelBoolean setOconEmoji = new SettingsModelBoolean(SET_ICON_EMOJI, false);
+		addSetting(SET_ICON_EMOJI, setOconEmoji);
+		
+		
+		setOconEmoji.addChangeListener(new ChangeListener() 
+		{
+			@Override
+			public void stateChanged(ChangeEvent e) 
+			{
+				iconEmoji.setEnabled(setOconEmoji.getBooleanValue());
+			}
+		});
+				
+	}
+
+	public Optional<String> getOptionalUsername()
+	{
+		return isSetUsername() ? Optional.of(getUsername()) : Optional.empty();
+	}
+	
+	
+	public String getUsername() {
+		return getSetting(USERNAME, SettingsModelString.class).getStringValue();
+	}
+	
+	public boolean isSetUsername()
+	{
+		return getBooleanValue(SET_USERNAME);
+	}
+	
+	public Optional<String> getOptionalIconUrl()
+	{
+		return getBooleanValue(SET_ICON_URL) ? Optional.of(getSetting(ICON_URL, SettingsModelString.class).getStringValue()) : Optional.empty();
+	}
+	
+	public Optional<String> getOptionalIconEmoji()
+	{
+		return getBooleanValue(SET_ICON_EMOJI) ? Optional.of(getSetting(ICON_EMOJI, SettingsModelString.class).getStringValue()) : Optional.empty();
+	}
+	
+	
+	public DialogComponent getDialogComponentUsername()
+	{
+		return new DialogComponentString(getSetting(USERNAME, SettingsModelString.class), "Username");
+	}
+	
+	public DialogComponent getDialogComponentSetUsername()
+	{
+		return new DialogComponentBoolean(getSetting(SET_USERNAME, SettingsModelBoolean.class), "Set username");
+	}	
+	
+	public DialogComponent getDialogComponentIconUrl()
+	{
+		return new DialogComponentString(getSetting(ICON_URL, SettingsModelString.class), "Icon URL");
+	}
+	
+	public DialogComponent getDialogComponentSetIconUrl()
+	{
+		return new DialogComponentBoolean(getSetting(SET_ICON_URL, SettingsModelBoolean.class), "Set Icon URL");
+	}	
+	
+	public DialogComponent getDialogComponentIconEmoji()
+	{
+		return new DialogComponentString(getSetting(ICON_EMOJI, SettingsModelString.class), "Icon emoji");
+	}
+	
+	public DialogComponent getDialogComponentSetIconEmoji()
+	{
+		return new DialogComponentBoolean(getSetting(SET_ICON_EMOJI, SettingsModelBoolean.class), "Set Icon emoji");
+	}
+	
+	
+}


### PR DESCRIPTION
The nodes for sending messages now allow the specification of iconUrl or iconEmoji. 

Shared dialog and setting created for reuse between nodes sending messages.