### PR TITLE
Added option to use channel name directly

### DIFF
--- a/com.sjwebb.knime.slack.feature/feature.xml
+++ b/com.sjwebb.knime.slack.feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="com.sjwebb.knime.slack.feature"
       label="Slack integration"
-      version="2.4.0.qualifier"
+      version="2.5.0.qualifier"
       provider-name="Samuel Webb">
 
    <description url="https://github.com/webbres/knime_slack/">

--- a/com.sjwebb.knime.slack/META-INF/MANIFEST.MF
+++ b/com.sjwebb.knime.slack/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Slack Integration - Node extension for KNIME Workbench
 Bundle-SymbolicName: com.sjwebb.knime.slack;singleton:=true
-Bundle-Version: 2.4.0.qualifier
+Bundle-Version: 2.5.0.qualifier
 Bundle-ClassPath: .,
  libs/javax.websocket-api-1.1.jar,
  libs/okio-1.13.0.jar,

--- a/com.sjwebb.knime.slack/src/com/sjwebb/knime/slack/nodes/messages/send/SendMessageNodeDialog.java
+++ b/com.sjwebb.knime.slack/src/com/sjwebb/knime/slack/nodes/messages/send/SendMessageNodeDialog.java
@@ -28,6 +28,7 @@ public class SendMessageNodeDialog extends MessageSendingDialog<SlackSendMessage
     	addDialogComponent(settings.getDialogCompoinentOathToken());
     	addDialogComponent(settings.getDialogCompoinentChannel());
     	addDialogComponent(settings.getDialogCompoinentMessage());
+    	addDialogComponent(settings.getDialogComponentLookup());
     	
     	addAdvancedSettings();
     }

--- a/com.sjwebb.knime.slack/src/com/sjwebb/knime/slack/nodes/messages/send/SendMessageNodeFactory.xml
+++ b/com.sjwebb.knime.slack/src/com/sjwebb/knime/slack/nodes/messages/send/SendMessageNodeFactory.xml
@@ -29,7 +29,8 @@
         <option name="Message">The message to post</option>
         <option name="Set username">Whether to use the custom provided username instead of bot name.</option>
         <option name="Username">A custom username to set, this will overide the default bot name. Ignored if Set username is not checked.</option>
-
+        <option name="Lookup conversation">If checked will lookup the conversation matching the channel name and pass on the channel ID otherwise passes the channel name directly to the API call</option>
+  
 
     </fullDescription>
     

--- a/com.sjwebb.knime.slack/src/com/sjwebb/knime/slack/nodes/messages/send/SendMessageNodeModel.java
+++ b/com.sjwebb.knime.slack/src/com/sjwebb/knime/slack/nodes/messages/send/SendMessageNodeModel.java
@@ -51,7 +51,14 @@ public class SendMessageNodeModel extends LocalSettingsNodeModel<SlackSendMessag
 //		
 //		api.postMessage(channel.get(), localSettings.getMessage());
 		
-		api.sendMessageToChannel(localSettings.getChannel(), localSettings.getMessage(), localSettings.getOptionalUsername(), localSettings.getOptionalIconUrl(), localSettings.getOptionalIconEmoji());
+		api.sendMessageToChannel(
+				localSettings.getChannel(), 
+				localSettings.getMessage(), 
+				localSettings.getOptionalUsername(), 
+				localSettings.getOptionalIconUrl(), 
+				localSettings.getOptionalIconEmoji(), 
+				localSettings.lookupConversation()
+				);
 		
 		BufferedDataTable[] out;
 		

--- a/com.sjwebb.knime.slack/src/com/sjwebb/knime/slack/nodes/messages/send/SlackSendMessageSettings.java
+++ b/com.sjwebb.knime.slack/src/com/sjwebb/knime/slack/nodes/messages/send/SlackSendMessageSettings.java
@@ -3,6 +3,7 @@ package com.sjwebb.knime.slack.nodes.messages.send;
 import org.knime.core.node.defaultnodesettings.DialogComponent;
 import org.knime.core.node.defaultnodesettings.DialogComponentMultiLineString;
 import org.knime.core.node.defaultnodesettings.DialogComponentString;
+import org.knime.core.node.defaultnodesettings.SettingsModelBoolean;
 import org.knime.core.node.defaultnodesettings.SettingsModelString;
 
 import com.sjwebb.knime.slack.util.SharedSendMessageSettings;
@@ -20,7 +21,6 @@ public class SlackSendMessageSettings extends SharedSendMessageSettings {
 
 		addSetting(CHANNEL, new SettingsModelString(CHANNEL, ""));
 		addSetting(MESSAGE, new SettingsModelString(MESSAGE, "Hello from KNIME"));
-		
 	}
 
 	
@@ -45,5 +45,9 @@ public class SlackSendMessageSettings extends SharedSendMessageSettings {
 	{
 		return new DialogComponentString(getSetting(CHANNEL, SettingsModelString.class), "Channel to send message to");
 	}
+
+
+
+
 
 }

--- a/com.sjwebb.knime.slack/src/com/sjwebb/knime/slack/nodes/messages/send/row/SendRowMessageNodeDialog.java
+++ b/com.sjwebb.knime.slack/src/com/sjwebb/knime/slack/nodes/messages/send/row/SendRowMessageNodeDialog.java
@@ -30,6 +30,7 @@ public class SendRowMessageNodeDialog extends MessageSendingDialog<SendRowMessag
     	setHorizontalPlacement(true);
     	addDialogComponent(settings.getDialogComponentChannel());
     	addDialogComponent(settings.getDialogComponentMessage());
+    	addDialogComponent(settings.getDialogComponentLookup());
     	
     	
     	addAdvancedSettings();

--- a/com.sjwebb.knime.slack/src/com/sjwebb/knime/slack/nodes/messages/send/row/SendRowMessageNodeFactory.xml
+++ b/com.sjwebb.knime.slack/src/com/sjwebb/knime/slack/nodes/messages/send/row/SendRowMessageNodeFactory.xml
@@ -29,7 +29,9 @@
         <option name="Message">The message content to send.</option>
         <option name="Set username">Whether to use the custom provided username instead of bot name.</option>
         <option name="Username">A custom username to set, this will overide the default bot name. Ignored if Set username is not checked.</option>
-
+        
+        
+        <option name="Lookup conversation">If checked will lookup the conversation matching the channel name and pass on the channel ID otherwise passes the channel name directly to the API call</option>
     </fullDescription>
     
     <ports>

--- a/com.sjwebb.knime.slack/src/com/sjwebb/knime/slack/nodes/messages/send/row/SendRowMessageNodeModel.java
+++ b/com.sjwebb.knime.slack/src/com/sjwebb/knime/slack/nodes/messages/send/row/SendRowMessageNodeModel.java
@@ -69,7 +69,13 @@ public class SendRowMessageNodeModel extends LocalSettingsNodeModel<SendRowMessa
 				{
 					try 
 					{
-						String timestamp = api.sendMessageToChannel(channel, message, localSettings.getOptionalUsername(), localSettings.getOptionalIconUrl(), localSettings.getOptionalIconEmoji());
+						String timestamp = api.sendMessageToChannel(
+								channel, 
+								message, 
+								localSettings.getOptionalUsername(), 
+								localSettings.getOptionalIconUrl(), 
+								localSettings.getOptionalIconEmoji(), 
+								localSettings.lookupConversation());
 						addRow(container, row, timestamp);
 					} catch (Exception e) 
 					{

--- a/com.sjwebb.knime.slack/src/com/sjwebb/knime/slack/nodes/messages/send/row/SendRowMessageSettings.java
+++ b/com.sjwebb.knime.slack/src/com/sjwebb/knime/slack/nodes/messages/send/row/SendRowMessageSettings.java
@@ -2,6 +2,7 @@ package com.sjwebb.knime.slack.nodes.messages.send.row;
 
 import org.knime.core.data.StringValue;
 import org.knime.core.node.defaultnodesettings.DialogComponent;
+import org.knime.core.node.defaultnodesettings.SettingsModelBoolean;
 import org.knime.core.node.defaultnodesettings.SettingsModelColumnName;
 
 import com.sjwebb.knime.slack.util.SharedSendMessageSettings;
@@ -69,6 +70,7 @@ public class SendRowMessageSettings extends SharedSendMessageSettings {
 	{
 		return getDialogColumnNameSelection(CONFIG_MESSAGE, "Message", 0, StringValue.class);
 	}
+
 	
 
 }

--- a/com.sjwebb.knime.slack/src/com/sjwebb/knime/slack/util/SharedSendMessageSettings.java
+++ b/com.sjwebb.knime.slack/src/com/sjwebb/knime/slack/util/SharedSendMessageSettings.java
@@ -32,6 +32,8 @@ public class SharedSendMessageSettings extends SlackOathTokenSettings
 	
 	private static final String DEFAULT_URL = "https://forum-cdn.knime.com/uploads/default/original/1X/ab3ccf34482a0329361734a18199390177204f15.png";
 	private static final String DEFAULT_EMOJI = ":chart_with_upwards_trend:";
+	
+	public static final String CONFIG_LOOKUP = "cfgLookup";
 
 	@Override
 	protected void addSettings() 
@@ -95,6 +97,7 @@ public class SharedSendMessageSettings extends SlackOathTokenSettings
 			}
 		});
 				
+		addSetting(CONFIG_LOOKUP, new SettingsModelBoolean(CONFIG_LOOKUP, true));
 	}
 
 	public Optional<String> getOptionalUsername()
@@ -153,5 +156,24 @@ public class SharedSendMessageSettings extends SlackOathTokenSettings
 		return new DialogComponentBoolean(getSetting(SET_ICON_EMOJI, SettingsModelBoolean.class), "Set Icon emoji");
 	}
 	
+	
+	/**
+	 * Dialog component for whether to lookup the conversation of use the channel name directly 
+	 * 
+	 * @return
+	 */
+	public DialogComponent getDialogComponentLookup()
+	{
+		return getBooleanComponent(CONFIG_LOOKUP, "Lookup conversation");
+	}
+
+
+	/**
+	 * Whether to lookup the conversation of use the channel name directly 
+	 * @return
+	 */
+	public boolean lookupConversation() {
+		return getBooleanValue(CONFIG_LOOKUP);
+	}
 	
 }


### PR DESCRIPTION
Added option to bypass conversation lookup to get the channel ID and instead pass the channel name directly. 

The slack API suggests using a channel ID but this may be causing problems for some users.