### PR TITLE
Added rate limit handling via aysnc methods

### DIFF
--- a/com.sjwebb.knime.slack.feature/feature.xml
+++ b/com.sjwebb.knime.slack.feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="com.sjwebb.knime.slack.feature"
       label="Slack integration"
-      version="2.6.2.qualifier"
+      version="2.7.0.qualifier"
       provider-name="Samuel Webb">
 
    <description url="https://github.com/webbres/knime_slack/">

--- a/com.sjwebb.knime.slack/META-INF/MANIFEST.MF
+++ b/com.sjwebb.knime.slack/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Slack Integration - Node extension for KNIME Workbench
 Bundle-SymbolicName: com.sjwebb.knime.slack;singleton:=true
-Bundle-Version: 2.6.2.qualifier
+Bundle-Version: 2.7.0.qualifier
 Bundle-ClassPath: .,
  libs/javax.websocket-api-1.1.jar,
  libs/okio-1.13.0.jar,

--- a/com.sjwebb.knime.slack/src/com/sjwebb/knime/slack/nodes/messages/send/SendMessageNodeFactory.xml
+++ b/com.sjwebb.knime.slack/src/com/sjwebb/knime/slack/nodes/messages/send/SendMessageNodeFactory.xml
@@ -21,6 +21,12 @@
        		set a username parameter. If changing the display name / username of the source of the message is desirable then check 'Set username' and 
        		provide the username to post the message as.
        	</p>
+       	
+       	<p>
+        	<b>Rate Limiting: </b>
+        	The underlying <a href="https://slack.dev/java-slack-sdk/guides/web-api-basics">Java Slack API</a> offers an async approach where it attempts to manage Rate Limits on API requests. 
+        	This node node uses the aysnc version of the method and will send approximately 1 message per second.
+        </p>
         
         </intro>
         

--- a/com.sjwebb.knime.slack/src/com/sjwebb/knime/slack/nodes/messages/send/SendMessageNodeModel.java
+++ b/com.sjwebb.knime.slack/src/com/sjwebb/knime/slack/nodes/messages/send/SendMessageNodeModel.java
@@ -1,6 +1,7 @@
 package com.sjwebb.knime.slack.nodes.messages.send;
 
 import java.io.IOException;
+import java.util.concurrent.CompletableFuture;
 
 import org.knime.core.data.DataTableSpec;
 import org.knime.core.node.BufferedDataTable;
@@ -49,8 +50,9 @@ public class SendMessageNodeModel extends SlackLocalSettingsNodeModel<SlackSendM
 		}
 //		
 //		api.postMessage(channel.get(), localSettings.getMessage());
+		exec.setMessage("Sending message");
 		
-		ChatPostMessageResponse response = api.sendMessageToChannel(
+		CompletableFuture<ChatPostMessageResponse> future = api.sendMessageToChannelAsync(
 				localSettings.getChannel(), 
 				localSettings.getMessage(), 
 				localSettings.getOptionalUsername(), 
@@ -58,6 +60,13 @@ public class SendMessageNodeModel extends SlackLocalSettingsNodeModel<SlackSendM
 				localSettings.getOptionalIconEmoji(), 
 				localSettings.lookupConversation()
 				);
+		
+		
+		exec.setMessage("Waiting on message send to complete");
+		
+		ChatPostMessageResponse response = future.get();
+		
+		exec.setMessage("Message sent");
 		
 		logResponse(response);
 		

--- a/com.sjwebb.knime.slack/src/com/sjwebb/knime/slack/nodes/messages/send/row/SendRowMessageNodeFactory.xml
+++ b/com.sjwebb.knime.slack/src/com/sjwebb/knime/slack/nodes/messages/send/row/SendRowMessageNodeFactory.xml
@@ -21,6 +21,13 @@
        		provide the username to post the message as.
        	</p>
         
+        
+        <p>
+        	<b>Rate Limiting: </b>
+        	The underlying <a href="https://slack.dev/java-slack-sdk/guides/web-api-basics">Java Slack API</a> offers an async approach where it attempts to manage Rate Limits on API requests. 
+        	This node node uses the aysnc version of the method and will send approximately 1 message per second.
+        </p>
+        
         </intro>
         
         

--- a/com.sjwebb.knime.slack/src/com/sjwebb/knime/slack/nodes/messages/send/row/SendRowMessageNodeModel.java
+++ b/com.sjwebb.knime.slack/src/com/sjwebb/knime/slack/nodes/messages/send/row/SendRowMessageNodeModel.java
@@ -1,6 +1,7 @@
 package com.sjwebb.knime.slack.nodes.messages.send.row;
 
 import java.io.IOException;
+import java.util.concurrent.CompletableFuture;
 
 import org.knime.core.data.DataCell;
 import org.knime.core.data.DataColumnSpecCreator;
@@ -77,16 +78,22 @@ public class SendRowMessageNodeModel extends SlackLocalSettingsNodeModel<SendRow
 
 				} else {
 
+					CompletableFuture<ChatPostMessageResponse> future = null;
 					ChatPostMessageResponse response = null;
 					try 
 					{
-						response = api.sendMessageToChannel(
+						future = api.sendMessageToChannelAsync(
 								channel, 
 								message, 
 								localSettings.getOptionalUsername(), 
 								localSettings.getOptionalIconUrl(), 
 								localSettings.getOptionalIconEmoji(), 
 								localSettings.lookupConversation());
+						
+						exec.setMessage("waiting on message sending to complete: " + row.getKey().getString());
+						
+						response = future.get();
+						exec.setMessage("");
 						
 						if(!response.isOk())
 						{

--- a/com.sjwebb.knime.slack/src/com/sjwebb/knime/slack/nodes/user/messages/send/MessageSlackUserNodeFactory.xml
+++ b/com.sjwebb.knime.slack/src/com/sjwebb/knime/slack/nodes/user/messages/send/MessageSlackUserNodeFactory.xml
@@ -33,6 +33,12 @@
 	       		set a username parameter. If changing the display name / username of the source of the message is desirable then check 'Set username' and 
 	       		provide the username to post the message as. The messages will however appear undo the app regardless of what username is set.
 	       	</p>
+	       	
+	       	<p>
+	        	<b>Rate Limiting: </b>
+	        	The underlying <a href="https://slack.dev/java-slack-sdk/guides/web-api-basics">Java Slack API</a> offers an async approach where it attempts to manage Rate Limits on API requests. 
+	        	This node node uses the aysnc version of the method and will send approximately 1 message per second.
+	        </p>
         
 			
         </intro>

--- a/com.sjwebb.knime.slack/src/com/sjwebb/knime/slack/nodes/user/messages/send/MessageSlackUserNodeModel.java
+++ b/com.sjwebb.knime.slack/src/com/sjwebb/knime/slack/nodes/user/messages/send/MessageSlackUserNodeModel.java
@@ -1,5 +1,7 @@
 package com.sjwebb.knime.slack.nodes.user.messages.send;
 
+import java.util.concurrent.CompletableFuture;
+
 import org.knime.core.data.DataTableSpec;
 import org.knime.core.data.DataTableSpecCreator;
 import org.knime.core.node.BufferedDataContainer;
@@ -40,10 +42,17 @@ public class MessageSlackUserNodeModel extends SlackLocalSettingsNodeModel<Messa
 
 		SlackBotApi api = new SlackBotApi(localSettings.getOathToken());
 
-		ChatPostMessageResponse response = null;
+		exec.setMessage("Sending message");
+		
+		CompletableFuture<ChatPostMessageResponse> future = null;
 		try
 		{
-			response = api.directMessage(localSettings.getUser(), localSettings.getMessage(), localSettings.getOptionalUsername(), localSettings.getOptionalIconUrl(), localSettings.getOptionalIconEmoji());
+			future = api.directMessageAsync(localSettings.getUser(), localSettings.getMessage(), localSettings.getOptionalUsername(), localSettings.getOptionalIconUrl(), localSettings.getOptionalIconEmoji());
+			
+			exec.setMessage("Waiting on message to complete");
+			ChatPostMessageResponse response = future.get();
+			
+			exec.setMessage("Processing response");
 			
 			logResponse(response);
 			


### PR DESCRIPTION
For nodes sending messages switched to use the methodsAsync call and
wait for the CompletableFuture to return before sending another message.

Not sure if this manages multiple nodes sending at the same time.

Bumped minor version number as this required no visible changes to the
user other than updating the node description XML.